### PR TITLE
GitHub actions: Unify installing dependencies step

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -24,8 +24,9 @@ jobs:
       run: |
         # We need to install git inside the container otherwise the checkout action will use Git
         # REST API and the .git directory won't be present which fails due to setuptools-scm
-        apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
-        pip install --upgrade pip nox
+
+        apt-get update
+        apt-get install --no-install-recommends --no-install-suggests -y git nox
 
     - uses: actions/checkout@v5
       with:
@@ -64,8 +65,9 @@ jobs:
       run: |
         # We need to install git inside the container otherwise the checkout action will use Git
         # REST API and the .git directory won't be present which fails due to setuptools-scm
-        apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
-        pip install --upgrade pip nox
+
+        apt-get update
+        apt-get install --no-install-recommends --no-install-suggests -y git nox python3-venv
 
     - uses: actions/checkout@v5
       with:
@@ -113,12 +115,10 @@ jobs:
     # ubuntu 24.04 and respect the YAML tag (revert the commit that added this)
     runs-on: ubuntu-24.04
     steps:
-      - name: Install required packages
+      - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install createrepo-c
-          python3 -m venv /var/tmp/venv
-          /var/tmp/venv/bin/pip3 install --upgrade pip nox
+          sudo apt-get install --no-install-recommends --no-install-suggests -y createrepo-c nox
 
       - name: add checkout action...
         uses: actions/checkout@v5
@@ -187,4 +187,4 @@ jobs:
           HERMETO_TEST_LOCAL_DNF_SERVER: 'true'
         run: |
           git config --global --add safe.directory "*"
-          /var/tmp/venv/bin/nox -s integration-tests
+          nox -s integration-tests


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
